### PR TITLE
Feature - TileIndex Shift

### DIFF
--- a/src/main/java/fr/LaurentFE/pacManCloneAgain/model/map/TileIndex.java
+++ b/src/main/java/fr/LaurentFE/pacManCloneAgain/model/map/TileIndex.java
@@ -26,4 +26,20 @@ public class TileIndex {
     y += ti.y;
     return this;
   }
+
+  public TileIndex getTileAbove() {
+    return new TileIndex(x, y - 1);
+  }
+
+  public TileIndex getTileOnRight() {
+    return new TileIndex(x + 1, y);
+  }
+
+  public TileIndex getTileBelow() {
+    return new TileIndex(x, y + 1);
+  }
+
+  public TileIndex getTileOnLeft() {
+    return new TileIndex(x - 1, y);
+  }
 }


### PR DESCRIPTION
TileIndex now has methods that return a new TileIndex object, corresponding to the tile above/on the right/below/on the left of the current TileIndex object.